### PR TITLE
Adds tasking manager badge logic (Task Champion, Scrutinizer, High St…

### DIFF
--- a/src/badge_logic/badge_cruncher.js
+++ b/src/badge_logic/badge_cruncher.js
@@ -21,8 +21,9 @@ module.exports.getBadgeProgress = function getBadgeProgress (user) {
     // waterwayKms: user.total_waterway_km_add,
     // gpsTraceKmAdd: user.total_gpstrace_km_add,
     countries: user.country_count,
-    // tasks: user.,
-    // taskEdits: user.,
+    tasks: user.total_tm_done_count,
+    taskValidations: user.total_tm_val_count,
+    taskInvalidations: user.total_tm_inval_count,
     josm: user.total_josm_edit_count,
     hashtags: Object.keys(user.hashtags).length
   });

--- a/src/badge_logic/sum_check.js
+++ b/src/badge_logic/sum_check.js
@@ -40,12 +40,12 @@ module.exports = function (data) {
     tasks: {
       name: 'Task Champion',
       id: 10,
-      tiers: {1: 5, 2: 20, 3: 50}
+      tiers: {1: 10, 2: 25, 3: 100}
     },
-    taskEdits: {
+    taskValidations: {
       name: 'Scrutinizer',
       id: 11,
-      tiers: {1: 5, 2: 20, 3: 50}
+      tiers: {1: 25, 2: 100, 3: 250}
     },
     josm: {
       name: 'Awesome JOSM',
@@ -56,6 +56,13 @@ module.exports = function (data) {
       name: 'Mapathoner',
       id: 13,
       tiers: {1: 5, 2: 20, 3: 50}
+    },
+
+    // ID #14 and 16 used by date check logic
+    taskInvalidations: {
+      name: 'High Standards',
+      id: 16,
+      tiers: {1: 25, 2: 100, 3: 250}
     }
   };
 

--- a/src/components/FullBadgeBox.js
+++ b/src/components/FullBadgeBox.js
@@ -18,9 +18,7 @@ function mapBadgeToDescrip (badge) {
     'Year-long Mapper': 'Map early, map often. Map as many days as you can to achieve new levels.',
     'Task Champion': 'Champions finish their work. Every task in the Tasking Manager needs to be finshed. Each new level is achieved by completing additional Tasking Manager squares.',
     'Scrutinizer': 'QA creates great products. Every square in the Tasking Manager needs to be validated. Each new level is achieved by validating new squares in the Tasking Manager.',
-    'Crisis Mapper': 'The Humanitarian OpenStreetMap Team (HOT) adds new tasks daily to collect data in high risk disaster areas. Map on HOT projects to reach new achievements.',
-    'Red Cross Mapper': "The Red Cross Missing Maps team is putting the world's more vulnerable people on the map. Map on Red Cross projects to reach new levels.",
-    'MSF Mapper': 'Medecins Sans Frontieres provides medical aid to countries around the world. Map on MSF projects to provide valuable data to their relief efforts and achieve new badge levels.'
+    'High Standards': 'Some maps need a bit more work to shine. Good QA demands an eye for detail and an uncompromising expectation of quality. Each new level is achieved by invalidating squares in the Tasking Manager.'
   };
   return map[badge];
 }
@@ -40,9 +38,7 @@ function mapBadgeToTask (badge, x) {
     'Year-long Mapper': (x) => `Map ${x} more days in total.`,
     'Task Champion': (x) => `Complete ${x} more HOTOSM tasks.`,
     'Scrutinizer': (x) => `Validate ${x} more HOTOSM tasks.`,
-    'Crisis Mapper': (x) => `Map on ${x} more HOTOSM projects.`,
-    'Red Cross Mapper': (x) => `Map on ${x} more Red Cross projects.`,
-    'MSF Mapper': (x) => `Map on ${x} more MSF projects.`
+    'High Standards': (x) => `Invalidate ${x} more HOTOSM tasks.`
   };
   return map[badge](x);
 }


### PR DESCRIPTION
@DylanMoriarty @smit1678 

Adds tasking manager badge logic (Task Champion, Scrutinizer, High Standards).
Will work after https://github.com/AmericanRedCross/osm-stats-workers/pull/25 has been merged.

This is ready for badge graphics to be developed. A blog post encouraging community involvement could also encourage volunteers to edit the descriptions and names (if you think it would give people a better sense of ownership, we could remove the existing descriptions from the PR).