### PR TITLE
Do not show calendar heatmap for future -- show recent contributions with respect to the page resize

### DIFF
--- a/src/components/ContributionBox.js
+++ b/src/components/ContributionBox.js
@@ -62,6 +62,8 @@ export default React.createClass({
       });
       return timestamps;
     };
+    var start = new Date();
+    start.setMonth(start.getMonth()-this.state.range+1);
     cal.init({
       domain: this.state.domain,
       range: this.state.range,
@@ -69,7 +71,7 @@ export default React.createClass({
       domainLabelFormat: this.state.domainLabelFormat,
       cellSize: this.state.cellSize,
       displayLegend: this.state.displayLegend,
-      start: new Date(data[0]),
+      start: start,
       data: data,
       dataType: 'json',
       domainGutter: 10,


### PR DESCRIPTION
I found it quite useless to show the heatmap of contributions for future year, ignoring all the contributions before the current month.
I changed to to show last year (or less) in respect to the screen width.

The original appearance (my timeline by today from [MissingMaps](http://www.missingmaps.org/users/#/1641564/)):
![image](https://cloud.githubusercontent.com/assets/2694489/24371903/a0a2aa76-132c-11e7-9130-0eac23ac34e8.png)

My modified version:
![image](https://cloud.githubusercontent.com/assets/2694489/24371966/cb7c51c0-132c-11e7-85ca-c3078faa1dde.png)

Scaling works as expected and pins the current month to the right side:
![image](https://cloud.githubusercontent.com/assets/2694489/24372018/f470c8f4-132c-11e7-9107-757e23f8ab2d.png)
